### PR TITLE
Remove stray closing div tag from base.html

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -85,7 +85,6 @@
     {% include 'snippets/dashboard_footer.html' %}
     {% endblock %}
   </footer>
-  </div>
 </body>
 
 </html>


### PR DESCRIPTION
It seems to be erroneous, but I might be mistaken due to use from other templates.