### PR TITLE
Support dark mode

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -130,6 +130,44 @@
         text-align: right;
         flex: 0 0 115px;
     }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background-color: #333;
+        color: #ddd;
+      }
+
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6,
+      strong,
+      b {
+        color:#eee;
+      }
+
+      a {
+        color: #8CC2DD;
+      }
+
+      code {
+        background-color: #777;
+      }
+
+      pre code {
+        color: #ddd;
+      }
+
+      blockquote {
+        color: #ccc;
+      }
+
+      .helptext {
+        color: #aaa;
+      }
+    }
   </style>
 </head>
 


### PR DESCRIPTION
(Possibly 😺) Fixes #44.

---

Hi @HermanMartinus, I just added this on my [self-hosted](https://github.com/janraasch/hugo-bearblog) »Hugo Bear Blog«-website https://www.janraasch.com to make the page a little bit easier on the eyes in dark environments (i.e. when using dark-mode).

Since I ran across #44, I thought I'd share this with you. Maybe this is useful for the platform...

This is what it looks like

![Screenshot_2020-09-29 Me and my projects 👨🏻‍🌾](https://user-images.githubusercontent.com/425211/94588683-87aafa00-0284-11eb-98b9-e3c132473213.png)

**Caveat:** The `.helptext`-color is a bit of a shot in the dark (pun not intended... 🤣) since that is not part of the frontend / user-facing design.