### PR TITLE
Properly pluralize upvote count

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -100,7 +100,7 @@ url("/hit/{{ post.pk }}")
         <button>▵ Toast this post</button>
         {% endif %}
     </form>
-    - <small>{{ post.upvote_count }} toasts</small>
+    - <small>{{ post.upvote_count }} toast{{ post.upvote_count|pluralize }}</small>
 </small>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
Currently, if a post has 1 toast, the page shows `1 toasts`. This PR updates the template to use Django's `pluralize` filter to check for a value of 1 and omit the `s`.