### PR TITLE
Fix asgiref conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 appdirs==1.4.3
-asgiref==3.2.7
+asgiref==3.2.10
 beautifulsoup4==4.9.1
 bleach==4.1.0
 certifi==2020.6.20


### PR DESCRIPTION
Fix for the following dependency error:
```
ERROR: Cannot install -r requirements.txt (line 10) and asgiref==3.2.7 because these package versions have conflict
ing dependencies.
```

The conflict is caused by:
    The user requested asgiref==3.2.7
    django 3.1.13 depends on asgiref<4 and >=3.2.10