### PR TITLE
Use <h2> for blog post titles instead of <h1> for better logical structure

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -57,9 +57,9 @@ url("/hit/{{ post.pk }}")
 {% block content %}
 
 {% if not post.is_page %}
-<h1>
+<h2>
     {{ post.title }}
-</h1>
+</h2>
 
 <p>
     <i>


### PR DESCRIPTION
If `<h1>` is used for the main blog title (and I agree it should be), it's more structurally logical to use `<h2>` for blog post titles and `<h3>` for section headings. When you use the [WAVE accessibility evaluation tool](https://wave.webaim.org) on the example blog, it gives this alert:

>![wave1](https://user-images.githubusercontent.com/72115097/168429921-88d3c3c6-91fd-4a45-9302-2f11d0823532.png)

>**Alerts**
>Skipped heading level

>Headings provide document structure and facilitate keyboard navigation by users of assistive technology. These users may be confused or experience difficulty navigating when heading levels are skipped.

>**What To Do**
>Restructure the document headings to ensure that heading levels are not skipped.