### PR TITLE
fix: check for upgraded status when uploading images

### DIFF
--- a/blogs/views/dashboard.py
+++ b/blogs/views/dashboard.py
@@ -101,7 +101,7 @@ def post_delete(request, pk):
 def upload_image(request):
     blog = get_object_or_404(Blog, user=request.user)
 
-    if request.method == "POST":
+    if request.method == "POST" and blog.upgraded == True:
         file_links = []
         time_string = str(time.time()).split('.')[0]
         count = 0


### PR DESCRIPTION
Before it was possible to upload images even when the user did not upgrade their blog.
This commit checks if the blog has been upgraded before processing the incoming file.