### PR TITLE
Fix  robots.txt’s sitemap

### DIFF
--- a/templates/robots.txt
+++ b/templates/robots.txt
@@ -1,5 +1,5 @@
 User-Agent: *
-Sitemap: {{ blog.useful_domain }}/sitemap.xml
+Sitemap: {% if blog %}{{ blog.useful_domain }}{% else %}https://bearblog.dev{% endif %}/sitemap.xml
 Disallow: /signup/
 Disallow: /accounts/
 Disallow: /dashboard/


### PR DESCRIPTION
Hi! Bear Blog is awesome. Thanks for making such a great web app.

I wanted to see how the landing page performed on page speed insights. The [result](https://pagespeed.web.dev/analysis/https-bearblog-dev/6l1ebz6xel?form_factor=mobile) is great!

![IMG_6900](https://github.com/HermanMartinus/bearblog/assets/8485687/27520027-ef3f-4272-8ae8-d42de16b35e7)

There is just one thing keeping you from a perfect score. Like sitemap.xml, robots.txt needs a conditional.