### PR TITLE
feat: Add Attributes and Markdown guidance to template editing

### DIFF
--- a/templates/studio/post_template_edit.html
+++ b/templates/studio/post_template_edit.html
@@ -16,6 +16,35 @@
         <button onclick="event.preventDefault(); window.location = '/{{ blog.subdomain }}/dashboard/posts/'">&#8592; Back</button>
         <button type="submit">Update</button>
     </p>
+
+    <details style="font-size: 12px; margin-bottom: 10px;">
+        <summary>
+            Attributes
+        </summary>
+        <p>
+            title: I like Bears<br>
+            link: i-like-bears<br>
+            alias: 2012/01/02/cool-post.html<br>
+            canonical_url: https://example.com/bears<br>
+            published_date: 2022-12-30 08:30<br>
+            is_page: false<br>
+            meta_description: Look for the bear necessities.<br>
+            meta_image: https://example.com/image.jpeg<br>
+            lang: en<br>
+            tags: {% if blog.tags %}{{ blog.tags|join:", " }}{% else %}bears, writing, thoughts{% endif %}<br>
+            make_discoverable: true
+        </p>
+        <a href="https://docs.bearblog.dev/post" target="_blank">
+            More info
+        </a>
+    </details>
+
     {{ form.as_p }}
+
+    <span class="helptext sticky">
+        <span>
+            <a href='https://herman.bearblog.dev/markdown-cheatsheet/' target='_blank'>Markdown syntax</a>
+        </span>
+    </span>
 </form>
 {% endblock %}

--- a/templates/studio/post_template_edit.html
+++ b/templates/studio/post_template_edit.html
@@ -23,7 +23,7 @@
         </summary>
         <p>
             title: Bears' title template<br>
-            link: bears-url-teamplate<br>
+            link: bears-url-template<br>
             is_page: false<br>
             meta_description: Meta necessities | Bear<br>
             meta_image: https://example.com/bear.jpeg<br>

--- a/templates/studio/post_template_edit.html
+++ b/templates/studio/post_template_edit.html
@@ -22,16 +22,13 @@
             Attributes
         </summary>
         <p>
-            title: I like Bears<br>
-            link: i-like-bears<br>
-            alias: 2012/01/02/cool-post.html<br>
-            canonical_url: https://example.com/bears<br>
-            published_date: 2022-12-30 08:30<br>
+            title: Bears' title template<br>
+            link: bears-url-teamplate<br>
             is_page: false<br>
-            meta_description: Look for the bear necessities.<br>
-            meta_image: https://example.com/image.jpeg<br>
+            meta_description: Meta necessities | Bear<br>
+            meta_image: https://example.com/bear.jpeg<br>
             lang: en<br>
-            tags: {% if blog.tags %}{{ blog.tags|join:", " }}{% else %}bears, writing, thoughts{% endif %}<br>
+            tags: bears, writing, thoughts<br>
             make_discoverable: true
         </p>
         <a href="https://docs.bearblog.dev/post" target="_blank">


### PR DESCRIPTION
**Use-case**
When adjusting my template to systematically include _meta_description_, I found myself wondering what other attributes would be worth specifying in my template. To do so I had to jump back to `New Post` to double-check the actual _Attributes_ examples.

**Suggestion**
The same way this list of _Attributes_ is valuable when writing a new post, I think it is equally valuable when editing the template. I therefore suggest to add them on the `Edit Template` page (and likewise for markdown syntax!).

**Sanity checks**

- Build/QA done: none
- Disclaimer: First contribution to this project! Unsure if I should have gone through some conventions and/or doing some local pre-validation
- Minimum I could do: run these changes through local browser inspector to get a feel of what it would look like

![Screenshot 2024-10-17 at 16 40 36](https://github.com/user-attachments/assets/c5a1b17e-6625-4b4b-928f-2db1a245bad4)

✨