### PR TITLE
fix: apply user specific footer to dashboard pages

### DIFF
--- a/templates/dashboard/analytics.html
+++ b/templates/dashboard/analytics.html
@@ -26,4 +26,7 @@
 <p>
     <a href="{% url 'upgrade' %}">Upgrade</a> to get access to in-depth, long-term analytics (<a href="https://herman.bearblog.dev/public-analytics/" target="_blank">example</a>).
 </p>
+
+{{ request.user.settings.dashboard_footer | safe }}
+
 {% endblock %}

--- a/templates/dashboard/media.html
+++ b/templates/dashboard/media.html
@@ -76,4 +76,7 @@ document.getElementById('deleteSelected').addEventListener('click', function() {
     }
 });
 </script>
+
+{{ request.user.settings.dashboard_footer | safe }}
+
 {% endblock %}

--- a/templates/dashboard/nav.html
+++ b/templates/dashboard/nav.html
@@ -26,4 +26,6 @@ textarea {
 }
 </style>
 
+{{ request.user.settings.dashboard_footer | safe }}
+
 {% endblock %}

--- a/templates/dashboard/posts.html
+++ b/templates/dashboard/posts.html
@@ -51,4 +51,7 @@
     </li>
     {% endfor %}
 </ul>
+
+{{ request.user.settings.dashboard_footer | safe }}
+
 {% endblock %}

--- a/templates/dashboard/styles.html
+++ b/templates/dashboard/styles.html
@@ -85,4 +85,7 @@
   }
 </script>
 {% endif %}
+
+{{ request.user.settings.dashboard_footer | safe }}
+
 {% endblock %}

--- a/templates/dashboard/subscribers.html
+++ b/templates/dashboard/subscribers.html
@@ -36,4 +36,7 @@
 {% empty %}No emails yet{% endfor %}{% endif %}</textarea>
     <small>One email address per line</small>
 </form>
+
+{{ request.user.settings.dashboard_footer | safe }}
+
 {% endblock %}


### PR DESCRIPTION
Add user specific footer to these pages to allow users to customize and add functions on these pages.

Why:
- User can use script to automatically send mail on mailing list page.
- User can use script to change color of background & text color of presets (which is hard to select with css selector) on styles/analytics page.
- User can use script to add helper function on media/nav page.