### PR TITLE
Add ID to tags div

### DIFF
--- a/templates/posts.html
+++ b/templates/posts.html
@@ -56,7 +56,7 @@
 
 
 <small>
-    <div class="tags">
+    <div class="tags" id="tags">
         {% for tag in blog.tags %}
             {% if tag not in active_tags and tag in available_tags %}
                 <a href="/blog/?q={% if active_tags %}{{ active_tags|join:',' }},{% endif %}{{ tag }}">#{{ tag }}</a>


### PR DESCRIPTION
Giving the tags div an ID allows an easy way to provide a link to see all of a blog's tags without needing to manually scroll to the bottom of a very long list of posts.