### PR TITLE
iframe whitelist: add archive.org

### DIFF
--- a/blogs/templatetags/custom_tags.py
+++ b/blogs/templatetags/custom_tags.py
@@ -49,7 +49,8 @@ HOST_WHITELIST = [
     'guestbooks.meadow.cafe',
     'supercut.video',
     'listenbrainz.org',
-    'api.listenbrainz.org'
+    'api.listenbrainz.org',
+    'archive.org'
 ]
 
 TYPOGRAPHIC_REPLACEMENTS = [


### PR DESCRIPTION
archive.org has an embed feature for albums and other media types. I was trying to embed this CC-licensed album in a post and discovered the iframe was blocked: https://archive.org/details/mtk123