### PR TITLE
pasting a link surrounds text in markdown link

### DIFF
--- a/templates/snippets/editor_functions.html
+++ b/templates/snippets/editor_functions.html
@@ -46,6 +46,42 @@
         }
     });
 
+	$textarea.addEventListener('paste', function(e) {
+		const selection = $textarea.value.substring($textarea.selectionStart, $textarea.selectionEnd);
+		
+		if (selection.length > 0) {
+			const pastedText = (e.clipboardData || window.clipboardData).getData('text');
+			
+			if (isUrl(pastedText)) {
+				e.preventDefault();
+				
+				const linkMarkdown = `[${selection}](${pastedText})`;
+				
+				// Use execCommand to preserve undo behavior (cmd+z will work)
+				if (document.execCommand && document.queryCommandSupported('insertText')) {
+					document.execCommand('insertText', false, linkMarkdown);
+				} else {
+					// Fallback for browsers that don't support execCommand
+					const start = $textarea.selectionStart;
+					const end = $textarea.selectionEnd;
+					// Replace selected text with markdown link syntax
+					$textarea.value = $textarea.value.substring(0, start) + linkMarkdown + $textarea.value.substring(end);
+					// Position cursor after the inserted link
+					$textarea.selectionStart = $textarea.selectionEnd = start + linkMarkdown.length;
+				}
+			}
+		}
+	});
+
+	function isUrl(string) {
+		try {
+			new URL(string);
+			return string.startsWith('http://') || string.startsWith('https://');
+		} catch {
+			return false;
+		}
+	}
+
 	// Handle saving scroll position
 	$textarea.scrollTop = sessionStorage.getItem('textareaY') || 0
 	$textarea.addEventListener("scroll", function(event) {


### PR DESCRIPTION
Hi!

I just started writing my first post with bearblog, and noticed a small behavior issue that bugged me: I'm used to being able to select some text and then paste a URL over it in most markdown editors. I implemented a small function to do so in bearblog. 

I used [document.execcomand](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand) where supported as this preserves the input history buffer, so `cmd+z` still works. there's a fallback if the API isn't supported by the user's browser.

the `isURL` function is as dead-simple as possible. it could possibly incorporate the `new URL()` constructor provided by the browser to more reliably identify links, but simpler felt better here.