### PR TITLE
fix: resolve #388 — Able to add X embeds in simple way

### DIFF
--- a/templates/blog/post.html
+++ b/templates/blog/post.html
@@ -1,0 +1,18 @@
+{% load blog_tags %}
+<!doctype html>
+<html lang="en">
+<head>
+ <meta charset="utf-8">
+ <meta name="viewport" content="width=device-width, initial-scale=1">
+ <title>{{ post.title }}</title>
+</head>
+<body>
+ <main>
+    <article>
+      <h1>{{ post.title }}</h1>
+      {{ post.content|embed_tweets|safe }}
+    </article>
+ </main>
+ {% twitter_widget_script %}
+</body>
+</html>


### PR DESCRIPTION
## Summary

fix: resolve #388 — Able to add X embeds in simple way

## Problem

**Severity**: `Medium` | **File**: `templates/blog/post.html`

Modify the blog post template to use the new `embed_tweets` filter on the post content and include the Twitter widget.js script tag at the bottom of the page to render the embedded tweets.

## Solution

Update the template to change `{{ post.content|safe }}` to `{{ post.content|embed_tweets|safe }}` and add `{% twitter_widget_script %}` just before the closing `</body>` tag. This ensures all tweet URLs in the content are converted to embed markup and the Twitter JavaScript is loaded to render them properly.

## Changes

- `templates/blog/post.html` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v5.8.1*