### PR TITLE
fix: resolve #420 — Login Page Doesn't Work w/ Password Autofill

### DIFF
--- a/blogs/templates/account/login.html
+++ b/blogs/templates/account/login.html
@@ -1,0 +1,38 @@
+{% extends "account/base.html" %}
+
+{% block head_title %}Sign in{% endblock %}
+
+{% block content %}
+<h1>Sign in</h1>
+
+<form class="login" method="POST" action="{% url 'account_login' %}">
+    {% csrf_token %}
+    <input type="hidden" name="next" value="{{ redirect_field_value }}" />
+
+    <label for="id_login">Email address</label>
+    <input
+        type="email"
+        name="login"
+        id="id_login"
+        autocomplete="email"
+        required
+    />
+
+    <label for="id_password">Password</label>
+    <input
+        type="password"
+        name="password"
+        id="id_password"
+        autocomplete="current-password"
+        required
+    />
+
+    <div>
+        <a href="{% url 'account_reset_password' %}">Forgot Password?</a>
+    </div>
+
+    <button type="submit">Sign in</button>
+</form>
+
+<p>Don't have an account? <a href="{% url 'account_signup' %}">Sign up</a></p>
+{% endblock %}


### PR DESCRIPTION
## Summary

fix: resolve #420 — Login Page Doesn't Work w/ Password Autofill

## Problem

**Severity**: `Low` | **File**: `blogs/templates/account/login.html`

Password managers like Bitwarden detect login forms by inspecting the `autocomplete` attribute on input fields. Without explicit `autocomplete` values, many password managers fail to recognize the form for autofill. The email/username field needs `autocomplete="email"` (or `"username"`) and the password field needs `autocomplete="current-password"`.

## Solution

Find the `<input>` elements in the login template and add the appropriate autocomplete attributes:

## Changes

- `blogs/templates/account/login.html` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*