### PR TITLE
fix: resolve #384 — Should Add a way to write blog posts through neovim

### DIFF
--- a/blogs/migrations/0040_blog_api_token.py
+++ b/blogs/migrations/0040_blog_api_token.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('blogs', '0039_blog_reviewed'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='blog',
+            name='api_token',
+            field=models.CharField(blank=True, max_length=64, null=True, unique=True),
+        ),
+    ]

--- a/blogs/models.py
+++ b/blogs/models.py
@@ -13,6 +13,7 @@ from math import log
 import random
 import string
 import hashlib
+import secrets
 import requests
 
 
@@ -59,6 +60,7 @@ class Blog(models.Model):
     subdomain = models.SlugField(max_length=100, unique=True, db_index=True)
     domain = models.CharField(max_length=128, blank=True, null=True, db_index=True)
     auth_token = models.CharField(max_length=128, blank=True)
+    api_token = models.CharField(max_length=64, blank=True, db_index=True)
 
     nav = models.TextField(default="[Home](/) [Blog](/blog/)", blank=True)
     content = models.TextField(default="Hello World!", blank=True)
@@ -144,6 +146,10 @@ class Blog(models.Model):
     def tags(self):
         return sorted(json.loads(self.all_tags))
     
+    def rotate_api_token(self):
+        self.api_token = secrets.token_urlsafe(32)
+        self.save(update_fields=['api_token'])
+
     def generate_auth_token(self):
         allowed_chars = string.ascii_letters.replace('O', '').replace('l', '')
         self.auth_token = ''.join(random.choice(allowed_chars) for _ in range(30))

--- a/blogs/views/api.py
+++ b/blogs/views/api.py
@@ -1,0 +1,85 @@
+import json
+
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
+from django.utils import timezone
+from django.utils.text import slugify
+
+from blogs.models import Blog, Post
+
+
+def _get_blog_from_token(request):
+    auth = request.META.get("HTTP_AUTHORIZATION", "")
+    if not auth.startswith("Token "):
+        return None
+    token = auth[6:].strip()
+    if not token:
+        return None
+    try:
+        return Blog.objects.get(api_token=token)
+    except Blog.DoesNotExist:
+        return None
+
+
+@csrf_exempt
+@require_http_methods(["POST", "PUT", "PATCH"])
+def post_api(request, slug=None):
+    blog = _get_blog_from_token(request)
+    if blog is None:
+        return JsonResponse({"error": "Invalid or missing API token."}, status=401)
+
+    try:
+        data = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON body."}, status=400)
+
+    if request.method == "POST":
+        title = data.get("title", "").strip()
+        if not title:
+            return JsonResponse({"error": "'title' is required."}, status=400)
+
+        content = data.get("content", "")
+        published = bool(data.get("published", False))
+        post_slug = data.get("slug") or slugify(title)
+
+        if Post.objects.filter(blog=blog, slug=post_slug).exists():
+            return JsonResponse({"error": "A post with this slug already exists."}, status=409)
+
+        post = Post.objects.create(
+            blog=blog,
+            title=title,
+            slug=post_slug,
+            content=content,
+            published=published,
+            publish_date=timezone.now() if published else None,
+        )
+        return JsonResponse({"slug": post.slug, "title": post.title, "published": post.published}, status=201)
+
+    # PUT / PATCH
+    if not slug:
+        return JsonResponse({"error": "'slug' is required in the URL for updates."}, status=400)
+
+    try:
+        post = Post.objects.get(blog=blog, slug=slug)
+    except Post.DoesNotExist:
+        return JsonResponse({"error": "Post not found."}, status=404)
+
+    if "title" in data:
+        post.title = data["title"].strip()
+    if "content" in data:
+        post.content = data["content"]
+    if "published" in data:
+        newly_published = bool(data["published"])
+        if newly_published and not post.published and post.publish_date is None:
+            post.publish_date = timezone.now()
+        post.published = newly_published
+    if "slug" in data:
+        new_slug = data["slug"].strip()
+        if new_slug and new_slug != post.slug:
+            if Post.objects.filter(blog=blog, slug=new_slug).exists():
+                return JsonResponse({"error": "A post with this slug already exists."}, status=409)
+            post.slug = new_slug
+
+    post.save()
+    return JsonResponse({"slug": post.slug, "title": post.title, "published": post.published}, status=200)

--- a/blogs/views/dashboard.py
+++ b/blogs/views/dashboard.py
@@ -2,6 +2,8 @@ from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, redirect, render
 from django.contrib.auth import get_user_model
 from django.utils.text import slugify
+from django.contrib import messages
+from django.views.decorators.http import require_POST
 
 from django.http import HttpResponse
 
@@ -15,6 +17,15 @@ import zipfile
 from blogs.forms import NavForm, StyleForm
 from blogs.helpers import get_country, is_protected
 from blogs.models import Blog, Post, Stylesheet
+
+
+@login_required
+@require_POST
+def rotate_api_token(request, id):
+    blog = get_object_or_404(Blog, user=request.user, subdomain=id)
+    token = blog.rotate_api_token()
+    messages.success(request, token)
+    return redirect('dashboard', id=blog.subdomain)
 
 
 @login_required

--- a/conf/urls.py
+++ b/conf/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path('mothership/', admin.site.urls),
     path('accounts/', include('allauth.urls')),
     path('', include('blogs.urls')),
+    path('api/', include('blogs.api_urls')),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
## Summary

fix: resolve #384 — Should Add a way to write blog posts through neovim

## Problem

**Severity**: `Medium` | **File**: `blogs/views/api.py`

New view module exposing a token-authenticated API so users can write and publish posts from external editors like Neovim. Should support POST to create a post and PUT/PATCH to update an existing one by slug. Returns JSON. Authentication via a user-scoped API token (stored on the Blog or UserSettings model).

## Solution



## Changes

- `blogs/views/api.py` (new)
- `blogs/migrations/0040_blog_api_token.py` (new)
- `blogs/models.py` (modified)
- `conf/urls.py` (modified)
- `blogs/views/dashboard.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*