### PR TITLE
fix: resolve #381 — Fix incorrect @type value in schema.org JSON-LD metadata

### DIFF
--- a/templates/discover.html
+++ b/templates/discover.html
@@ -5,7 +5,7 @@
 
 {% block seo %}
 <meta name="robots" content="nofollow">
-{% include 'snippets/seo_tags.html' with site_name='ʕ•ᴥ•ʔ Bear Blog' type="website" title='Discovery feed' url='https://bearblog.dev/discover' description='Discover articles and blogs on Bear' image="https://bear-images.sfo2.cdn.digitaloceanspaces.com/herman-1683556668-0.png" %}
+{% include 'snippets/seo_tags.html' with site_name='ʕ•ᴥ•ʔ Bear Blog' type="WebSite" title='Discovery feed' url='https://bearblog.dev/discover' description='Discover articles and blogs on Bear' image="https://bear-images.sfo2.cdn.digitaloceanspaces.com/herman-1683556668-0.png" %}
 <link rel="alternate" type="application/atom+xml" href="/feed/{% if newest %}?newest=True{% endif %}" title="{% if newest %}Most recent{% else %}Trending{% endif %} | Bear Blog">
 <link rel="alternate" type="application/rss+xml" href="feed/?type=rss{% if newest %}&newest=True{% endif %}" title="{% if newest %}Most recent{% else %}Trending{% endif %} | Bear Blog">
 {% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -17,7 +17,7 @@
 
 <meta name="{{ blog.subdomain }}" content="look-for-the-bear-necessities">
 
-{% include 'snippets/seo_tags.html' with site_name=blog.title title=blog.title type="website" url=blog.useful_domain description=meta_description image=blog.meta_image meta_tag=blog.meta_tag %}
+{% include 'snippets/seo_tags.html' with site_name=blog.title title=blog.title type="WebSite" url=blog.useful_domain description=meta_description image=blog.meta_image meta_tag=blog.meta_tag %}
 <link rel="alternate" type="application/atom+xml" href="/feed/" title="{{ blog.title }}">
 <link rel="alternate" type="application/rss+xml" href="/feed/?type=rss" title="{{ blog.title }}">
 {% endblock %}

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block seo %}
-{% include 'snippets/seo_tags.html' with site_name='ʕ•ᴥ•ʔ Bear Blog' type="website" title='ʕ•ᴥ•ʔ Bear Blog' url='https://bearblog.dev' description='Free, no-nonsense, super-fast blogging' image="https://bear-images.sfo2.cdn.digitaloceanspaces.com/herman-1683556668-0.png" %}
+{% include 'snippets/seo_tags.html' with site_name='ʕ•ᴥ•ʔ Bear Blog' type="WebSite" title='ʕ•ᴥ•ʔ Bear Blog' url='https://bearblog.dev' description='Free, no-nonsense, super-fast blogging' image="https://bear-images.sfo2.cdn.digitaloceanspaces.com/herman-1683556668-0.png" %}
 {% endblock %}
 
 {% block nav %}

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -16,7 +16,7 @@
 
 <meta name="{{ blog.subdomain }}" content="look-for-the-bear-necessities">
 
-{% include 'snippets/seo_tags.html' with site_name=blog.title title=blog_path_title type="website" url=blog.useful_domain description=blog.meta_description image=blog.meta_image meta_tag=blog.meta_tag %}
+{% include 'snippets/seo_tags.html' with site_name=blog.title title=blog_path_title type="WebSite" url=blog.useful_domain description=blog.meta_description image=blog.meta_image meta_tag=blog.meta_tag %}
 <link rel="alternate" type="application/atom+xml" href="/feed/{% if query %}?q={{ query }}{% endif %}" title="{{ blog.title }}">
 <link rel="alternate" type="application/rss+xml" href="/feed/?type=rss{% if query %}&q={{ query }}{% endif %}" title="{{ blog.title }}">
 {% endblock %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -5,7 +5,7 @@
 
 {% block seo %}
 <meta name="robots" content="nofollow">
-{% include 'snippets/seo_tags.html' with site_name='ʕ•ᴥ•ʔ Bear Blog' type="website" title='Search Results' url='https://bearblog.dev/search' description='Search results on Bear Blog' image="https://bear-images.sfo2.cdn.digitaloceanspaces.com/herman-1683556668-0.png" %}
+{% include 'snippets/seo_tags.html' with site_name='ʕ•ᴥ•ʔ Bear Blog' type="WebSite" title='Search Results' url='https://bearblog.dev/search' description='Search results on Bear Blog' image="https://bear-images.sfo2.cdn.digitaloceanspaces.com/herman-1683556668-0.png" %}
 {% endblock %}
 
 {% block nav %}


### PR DESCRIPTION
## Summary

fix: resolve #381 — Fix incorrect @type value in schema.org JSON-LD metadata

## Problem

**Severity**: `High` | **File**: `templates/discover.html`

The schema.org @type value is incorrectly set to "website" instead of "WebSite" according to the official specification. This affects SEO and structured data validation.

## Solution

Change "@type": "website" to "@type": "WebSite" on line 7

## Changes

- `templates/discover.html` (modified)
- `templates/home.html` (modified)
- `templates/landing.html` (modified)
- `templates/posts.html` (modified)
- `templates/search.html` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced