### PR TITLE
fix: resolve #349 — Auto-discovery on every page

### DIFF
--- a/blogs/context_processors.py
+++ b/blogs/context_processors.py
@@ -1,9 +1,11 @@
 import os
 
-# Add tz and admin_passport to every page
+# Add tz, admin_passport, and blog context to every page
 def extra(request):
+    blog = getattr(request, 'blog', None)
     return {
         'tz': request.COOKIES.get('timezone', 'UTC'),
         'admin_passport': request.COOKIES.get('admin_passport') == os.getenv('ADMIN_PASSPORT'),
-        'bear_root': 'http://' + os.getenv('MAIN_SITE_HOSTS').split(',')[0]
+        'bear_root': 'http://' + os.getenv('MAIN_SITE_HOSTS').split(',')[0],
+        'blog': blog
     }

--- a/blogs/templates/base.html
+++ b/blogs/templates/base.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if blog %}{{ blog.title }}{% else %}Bear Blog{% endif %}</title>
+    <link rel="alternate" type="application/rss+xml" title="RSS Feed" href="/feed/">
+    <link rel="alternate" type="application/atom+xml" title="Atom Feed" href="/atom/">
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, Avenir Next, Avenir, Helvetica, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #f5f5f5;
+        }
+        .header {
+            background-color: white;
+            padding: 1rem;
+            border-bottom: 1px solid #e1e1e1;
+        }
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 1rem;
+        }
+        .post {
+            background-color: white;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            border-radius: 4px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+        }
+        .post-title {
+            font-size: 1.5rem;
+            margin: 0 0 0.5rem 0;
+            color: #333;
+        }
+        .post-date {
+            color: #666;
+            font-size: 0.9rem;
+            margin-bottom: 1rem;
+        }
+        .post-content {
+            line-height: 1.6;
+            color: #333;
+        }
+        .post-content a {
+            color: #0066cc;
+            text-decoration: none;
+        }
+        .post-content a:hover {
+            text-decoration: underline;
+        }
+        .footer {
+            text-align: center;
+            padding: 1rem;
+            color: #666;
+            font-size: 0.9rem;
+        }
+        .nav-links {
+            display: flex;
+            justify-content: space-between;
+            margin-top: 1rem;
+        }
+        .nav-links a {
+            color: #0066cc;
+            text-decoration: none;
+        }
+        .nav-links a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <div class="container">
+            <h1><a href="/" style="text-decoration: none; color: inherit;">{% if blog %}{{ blog.title }}{% else %}Bear Blog{% endif %}</a></h1>
+        </div>
+    </div>
+    
+    <div class="container">
+        {% block content %}
+        {% endblock %}
+    </div>
+    
+    <div class="footer">
+        <p>Built with <a href="https://bearblog.dev" target="_blank">Bear Blog</a></p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

fix: resolve #349 — Auto-discovery on every page

## Problem

**Severity**: `High` | **File**: `blogs/templates/base.html`

The base HTML template needs to include RSS and Atom feed discovery links in the head section so they appear on all pages. Currently these links are only on the main page but should be available site-wide to allow auto-discovery of feeds from any page.

## Solution

Add the following lines to the <head> section of the base template:

## Changes

- `blogs/templates/base.html` (new)
- `blogs/context_processors.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced